### PR TITLE
Add localised salary figures

### DIFF
--- a/jquery/compound-inflation-calculator-solo.js
+++ b/jquery/compound-inflation-calculator-solo.js
@@ -4,6 +4,17 @@ function setButtonValue() {
 }
 
 function calculateInflation(){
+  // Get browser language (+ region)
+  var browserLang = navigator.language || navigator.userLanguage;
+  var browserLangCode = browserLang.split('-')[0]; // Get language code without region
+
+  // Get selected language from localStorage or default to browser language or English
+  var storedLang = localStorage.getItem('selectedLanguage');
+  var lang = storedLang || browserLangCode || 'en';
+
+  // Choose number locale: (browser lang = selected lang) => user's regional format; otherwise language's default format
+  var numberLocale = (browserLangCode == lang) ? browserLang : lang;
+
   // Get user inputs
   var currentSalary = document.getElementById('currentSalary').value;
   var inflationRate = document.getElementById('inflationRate').value;
@@ -15,8 +26,8 @@ function calculateInflation(){
   } else {
     // Calculate inflation
     var totalInflation = Math.pow((1 + (inflationRate/100)), years);
-    var dollarSalary = (currentSalary * 1).toLocaleString("en-US", {style: "currency", currency: "USD"});
-    var newSalary = (currentSalary * totalInflation).toLocaleString("en-US", {style: "currency", currency: "USD"});
+    var dollarSalary = (currentSalary * 1).toLocaleString(numberLocale, {style: "currency", currency: "USD"});
+    var newSalary = (currentSalary * totalInflation).toLocaleString(numberLocale, {style: "currency", currency: "USD"});
 
     // Display result
     var yearText = (years == 1) ?  $.i18n('common_year') : $.i18n('common_years');

--- a/jquery/compound-inflation-calculator.js
+++ b/jquery/compound-inflation-calculator.js
@@ -18,6 +18,18 @@
 
   // Function to calculate inflation
   function calculateInflation(resultId, idPostfix) {
+    // Get browser language (+ region)
+    var browserLang = navigator.language || navigator.userLanguage;
+    var browserLangCode = browserLang.split('-')[0]; // Get language code without region
+
+    // Get selected language from localStorage or default to browser language or English
+    var storedLang = localStorage.getItem('selectedLanguage');
+    var lang = storedLang || browserLangCode || 'en';
+
+    // Choose number locale: (browser lang = selected lang) => user's regional format; otherwise language's default format
+    var numberLocale = (browserLangCode == lang) ? browserLang : lang;
+    console.log(browserLang, lang, numberLocale);
+
     // Get user inputs
     var currentSalary = document.getElementById('currentSalary' + idPostfix).value;
     var inflationRate = document.getElementById('inflationRate' + idPostfix).value;
@@ -29,8 +41,8 @@
     } else {
       // Calculate inflation
       var totalInflation = Math.pow((1 + (inflationRate / 100)), years);
-      var dollarSalary = (currentSalary * 1).toLocaleString("en-US", { style: "currency", currency: selectedCurrency });
-      var newSalary = (currentSalary * totalInflation).toLocaleString("en-US", { style: "currency", currency: selectedCurrency });
+      var dollarSalary = (currentSalary * 1).toLocaleString(numberLocale, { style: "currency", currency: selectedCurrency });
+      var newSalary = (currentSalary * totalInflation).toLocaleString(numberLocale, { style: "currency", currency: selectedCurrency });
 
       // Display result in the specified result div
       var yearText = (years == 1) ? $.i18n('common_year') : $.i18n('common_years');


### PR DESCRIPTION
This adds localised salary figures to the result message for both the standalone calculator at '/compound-inflation-calculator.html' and the calculator at '/inflation.html', as discussed [here](https://github.com/sovenor/bitcoin-rocks/issues/16#issuecomment-2126633558).

It determines the locale based on the selected language. If the selected language and the browser language match, it uses the regional format, otherwise it uses the standard format for that language.